### PR TITLE
Fixed logical error in account checking middleware

### DIFF
--- a/utilities/account_checker.js
+++ b/utilities/account_checker.js
@@ -1,17 +1,18 @@
 const Express = require('express');
-const {UserRole} = require('../models/User')
+const { UserRole } = require('../models/User')
+
 
 /**
  * 
  * @param {Express.Request} req Express Request handle
  * @param {Express.Response} res Express Response handle
  */
-const isLoggedIn = function(req,res,next){
-    if (req.isAuthenticated()){
-        next();
-    }else{
-        res.redirect('/auth/login');
-    }
+const isLoggedIn = function (req, res, next) {
+	if (req.isAuthenticated()) {
+		return next();
+	} else {
+		return res.redirect('/auth/login');
+	}
 };
 
 /**
@@ -19,12 +20,12 @@ const isLoggedIn = function(req,res,next){
  * @param {Express.Request} req Express Request handle
  * @param {Express.Response} res Express Response handle
  */
- const isNotLoggedIn = function(req,res,next){
-    if (req.isAuthenticated() == null){
-        next();
-    }else{
-        res.redirect('/');
-    }
+const isNotLoggedIn = function (req, res, next) {
+	if (req.isAuthenticated()) {
+		return res.redirect('/');
+	} else {
+		return next();
+	}
 };
 
 /**
@@ -32,18 +33,20 @@ const isLoggedIn = function(req,res,next){
  * @param {Express.Request} req Express Request handle
  * @param {Express.Response} res Express Response handle
  */
-const isAdmin = function(req,res,next){
-    if (req.isAuthenticated()){
-        if (req.user.role == UserRole.Admin){
-            console.log(req.user.role);
-            next();
-        }
-        else {
-            res.send("Not an admin").end();
-        }
-    }else{
-        res.redirect('/auth/login');
-    }
+const isAdmin = function (req, res, next) {
+	if (req.isAuthenticated()) {
+		if (req.user.role == UserRole.Admin) {
+			return next();
+		}
+		else {
+			console.log(`Current user is not privileged to access admin portal: ${req.user.uuid}`);
+			return res.sendStatus(403).end();
+		}
+	} 
+	else {
+		console.log(`Either session expired or not logged in`);
+		return res.redirect('/auth/login');
+	}
 }
 
-module.exports = {isLoggedIn, isNotLoggedIn, isAdmin};
+module.exports = { isLoggedIn, isNotLoggedIn, isAdmin };


### PR DESCRIPTION
`req.isAuthenticated()` returns a bool, causing invalid condition within `isNotLoggedIn`.
As such indirectly causes passport to not serialize / deserialize the logged in user from session cookie.